### PR TITLE
Notification header colors should use ColorInt instead of ColorRes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha14'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha17'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/library/src/main/java/io/karn/notify/entities/Payload.kt
+++ b/library/src/main/java/io/karn/notify/entities/Payload.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import android.media.RingtoneManager
 import android.net.Uri
 import android.support.annotation.ColorInt
-import android.support.annotation.ColorRes
 import android.support.annotation.DrawableRes
 import android.support.v4.app.NotificationCompat
 import io.karn.notify.Notify
@@ -129,7 +128,7 @@ sealed class Payload {
             /**
              * The color of the notification items -- icon, appName, and expand indicator.
              */
-            @ColorRes var color: Int = R.color.notification_header_color,
+            @ColorInt var color: Int = 0x4A90E2,
             /**
              * The optional text that appears next to the appName of a notification.
              */

--- a/library/src/main/java/io/karn/notify/internal/NotificationInterop.kt
+++ b/library/src/main/java/io/karn/notify/internal/NotificationInterop.kt
@@ -99,7 +99,7 @@ internal object NotificationInterop {
                 // Ensures that this notification is marked as a Notify notification.
                 .extend(NotifyExtender())
                 // The color of the RawNotification Icon, App_Name and the expanded chevron.
-                .setColor(notify.context.resources.getColor(payload.header.color))
+                .setColor(payload.header.color)
                 // The RawNotification icon.
                 .setSmallIcon(payload.header.icon)
                 // The text that is visible to the right of the app name in the notification header.

--- a/library/src/test/java/io/karn/notify/NotifyHeaderTest.kt
+++ b/library/src/test/java/io/karn/notify/NotifyHeaderTest.kt
@@ -53,8 +53,8 @@ class NotifyHeaderTest : NotifyTestBase() {
 
         Assert.assertEquals(context.resources.getDrawable(testIcon, context.theme), notification.smallIcon.loadDrawable(context))
         Assert.assertEquals(
-                String.format("#%06X", context.resources.getColor(testColor, context.theme)),
-                String.format("#%06X", 0xFFFFFFFF and notification.color.toLong()))
+                String.format("#%06X", testColor),
+                String.format("#%06X", 0xFFFFFF and notification.color))
         Assert.assertEquals(testHeaderText, notification.extras.getCharSequence(NotificationCompat.EXTRA_SUB_TEXT))
         Assert.assertEquals(testShowTimestamp, notification.extras.getBoolean(NotificationCompat.EXTRA_SHOW_WHEN))
     }

--- a/library/src/test/java/io/karn/notify/NotifyHeaderTest.kt
+++ b/library/src/test/java/io/karn/notify/NotifyHeaderTest.kt
@@ -33,7 +33,7 @@ class NotifyHeaderTest : NotifyTestBase() {
     @Test
     fun modifiedHeaderTest() {
         val testIcon = R.drawable.ic_android_black
-        val testColor = android.R.color.holo_purple
+        val testColor = 0xAA66CC
         val testHeaderText = "New Menu!"
         val testShowTimestamp = false
 

--- a/sample/src/main/java/presentation/MainActivity.kt
+++ b/sample/src/main/java/presentation/MainActivity.kt
@@ -18,7 +18,7 @@ class MainActivity : AppCompatActivity() {
 
         Notify.defaultConfig {
             header {
-                color = R.color.colorPrimaryDark
+                color = resources.getColor(R.color.colorPrimaryDark)
             }
             alerting(Notify.CHANNEL_DEFAULT_KEY) {
                 lightColor = Color.RED


### PR DESCRIPTION
**Issue**: #15 

**Proposed changes**:
- Notification header colors should use ColorInt instead of ColorRes.

**Notes**:
- This is a breaking change.
